### PR TITLE
feat(root): less output, 1-day cache

### DIFF
--- a/app/routes/root.py
+++ b/app/routes/root.py
@@ -19,7 +19,7 @@ api = Api(root_bp)
 
 class Root(Resource):
     """Main page route."""
-    @cache.cached(timeout=config.CACHE_DEFAULT_TIMEOUT)
+    @cache.cached(timeout=86400)
     def get(self):
         """The main page shows a status message and other informations"""
         return {
@@ -28,26 +28,17 @@ class Root(Resource):
             "version": AppMetadata.APP_VERSION,
             "description": AppMetadata.APP_DESCRIPTION,
             "routes": {
-                "java_full": "/api/java/full/{ip}/{port?}",
-                "java_players": "/api/java/playercount/{ip}/{port?}",
-                "java_latency": "/api/java/latency/{ip}{port?}",
-
-                "legacy_full": "/api/legacy/full/{ip}/{port?}",
-                "legacy_players": "/api/legacy/playercount/{ip}/{port?}",
-                "legacy_latency": "/api/legacy/latency/{ip}{port?}",
-
-                "bedrock_full": "/api/bedrock/full/{ip}/{port?}",
-                "bedrock_players": "/api/bedrock/playercount/{ip}/{port?}",
-                "bedrock_latency": "/api/bedrock/latency/{ip}/{port?}"
+                "full": "/api/{server_type}/full/{ip}/{port?}",
+                "player_amount": "/api/{server_type}/playercount/{ip}/{port?}",
+                "latency": "/api/{server_type}/latency/{ip}{port?}",
             },
+            "server_types": ["java", "legacy", "bedrock"],
             "default_ports": {
                 "java": DefaultPorts.JAVA,
                 "legacy": DefaultPorts.LEGACY,
                 "bedrock": DefaultPorts.BEDROCK
             },
-            "cache": {
-                "cache_timeout_ms": config.CACHE_DEFAULT_TIMEOUT * 1000
-            }
+            "cache_timeout_ms": config.CACHE_DEFAULT_TIMEOUT * 1000
         }, HTTPStatus.OK
 
 


### PR DESCRIPTION
- Reduced amount of displayed information.
- The content of this page is static so increased cache to 1 entire day.